### PR TITLE
implementation of sfrac command for beveled fractions; references for Ma...

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -2605,6 +2605,24 @@ MathJax.Hub.Config({
         scale: 88,
     },
 });
+    <xsl:if test="//m[contains(text(),'sfrac')] or //md[contains(text(),'sfrac')] or //me[contains(text(),'sfrac')] or //mrow[contains(text(),'sfrac')]">
+    /* support for the sfrac command in MathJax (Beveled fraction)
+        see: https://github.com/mathjax/MathJax-docs/wiki/Beveled-fraction-like-sfrac,-nicefrac-bfrac */
+MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
+  var MML = MathJax.ElementJax.mml,
+      TEX = MathJax.InputJax.TeX;
+
+  TEX.Definitions.macros.sfrac = "myBevelFraction";
+
+  TEX.Parse.Augment({
+    myBevelFraction: function (name) {
+      var num = this.ParseArg(name),
+          den = this.ParseArg(name);
+      this.Push(MML.mfrac(num,den).With({bevelled: true}));
+    }
+  });
+});
+    </xsl:if>
 </script>
 <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML-full" />
 </xsl:template>

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -332,6 +332,10 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Need CDATA here to protect inequalities as part of an XML file -->
     <xsl:text><![CDATA[\newcommand{\lt}{<}]]>&#xa;</xsl:text>
     <xsl:text><![CDATA[\newcommand{\gt}{>}]]>&#xa;</xsl:text>
+    <xsl:if test="//m[contains(text(),'sfrac')] or //md[contains(text(),'sfrac')] or //me[contains(text(),'sfrac')] or //mrow[contains(text(),'sfrac')]">
+        <xsl:text>%% xfrac package for 'beveled fractions': http://tex.stackexchange.com/questions/3372/how-do-i-typeset-arbitrary-fractions-like-the-standard-symbol-for-5-%C2%BD&#xa;</xsl:text>
+        <xsl:text>\usepackage{xfrac}&#xa;</xsl:text>
+    </xsl:if>
     <xsl:text>%% Semantic Macros&#xa;</xsl:text>
     <xsl:text>%% To preserve meaning in a LaTeX file&#xa;</xsl:text>
     <xsl:text>%% Only defined here if required in this document&#xa;</xsl:text>


### PR DESCRIPTION
...thJax and LaTeX within

This is a test of our new implementation.

I ran the following:

`git checkout -b feature/bfrac origin/dev`

and then made the changes. 

To test, add an `\sfrac{1}{2}` to any mathmode environment, and then run 

`xsltproc xsl/mathbook-latex.xsl examples/sample-article.xml`

and

`xsltproc xsl/mathbook-html.xsl examples/sample-article.xml`

You should see that in the `.tex` version, the `xfrac` package is loaded conditionally. In the `.html` version, you should see that the `MathJax` configuration is added conditionally.

Hopefully I'm submitting this to the appropriate branch. If you'd like to submit this to Rob's `dev` branch, feel free :)
