### PR TITLE
Table enhancements

### DIFF
--- a/examples/sample-article.xml
+++ b/examples/sample-article.xml
@@ -619,6 +619,52 @@ the xsltproc executable.
             <caption>Euler's approximation for Duffing's Equation with <m>h = 0.2</m></caption>
             </table>
 
+                <table>
+                  <caption/>
+                  <coltypes>
+                    <col align="decimal" format="2.0"/>
+                    <col align="decimal" format="1.2"/>
+                    <col align="decimal" format="1.4"/>
+                    <col align="decimal" format="1.4"/>
+                  </coltypes>
+                  <thead>
+                        <row><entry><m>i</m></entry><entry><m>t_i</m></entry><entry><m>x_i</m></entry><entry><m>y_i</m></entry></row>
+                  </thead>
+                  <tbody>
+                        <row><entry>0</entry><entry>0</entry><entry>0</entry><entry>0.5000</entry></row>
+                        <row><entry>1</entry><entry>0.20</entry><entry>0.1000</entry><entry>0.4800</entry></row>
+                        <row><entry>2</entry><entry>0.40</entry><entry>0.1960</entry><entry>0.4560</entry></row>
+                        <row><entry>3</entry><entry>0.60</entry><entry>0.2872</entry><entry>0.4295</entry></row>
+                        <row><entry>4</entry><entry>0.80</entry><entry>0.3731</entry><entry>0.4027</entry></row>
+                        <row><entry>5</entry><entry>1.00</entry><entry>0.4536</entry><entry>0.3783</entry></row>
+                        <row><entry>6</entry><entry>1.20</entry><entry>0.5293</entry><entry>0.3591</entry></row>
+                        <row><entry>7</entry><entry>1.40</entry><entry>0.6011</entry><entry>0.3480</entry></row>
+                        <row><entry>8</entry><entry>1.60</entry><entry>0.6707</entry><entry>0.3474</entry></row>
+                        <row><entry>9</entry><entry>1.80</entry><entry>0.7402</entry><entry>0.3603</entry></row>
+                        <row><entry>10</entry><entry>2.00</entry><entry>0.8123</entry><entry>0.3900</entry></row>
+                  </tbody>
+                </table>
+
+                <table>
+                  <caption/>
+                  <coltypes>
+                    <col align="center"/>
+                    <col align="left"/>
+                    <col align="right"/>
+                    <col align="decimal" format="4.4"/>
+                    <col align="decimal" format="6.5"/>
+                  </coltypes>
+                  <thead>
+                    <row><entry>Month</entry><entry>Name</entry><entry>Country</entry><entry>Savings</entry><entry>Other</entry></row>
+                  </thead>
+                  <tbody>
+                    <row><entry>January</entry><entry>Chris</entry><entry>UK</entry><entry>13.3</entry><entry>000.3</entry></row>
+                    <row><entry>February</entry><entry>Alex</entry><entry>USA</entry><entry>3.34</entry><entry>1.00000</entry></row>
+                    <row><entry>March</entry><entry>Rob</entry><entry>USA</entry><entry>103.34</entry><entry>100000</entry></row>
+                    <row><entry>April</entry><entry>Carl</entry><entry>Malaysia</entry><entry>??</entry><entry>10.0000</entry></row>
+                  </tbody>
+                </table>
+
         </section>
 
         <section>

--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -99,6 +99,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:param name="directory.images" select="'images'" />
 <xsl:param name="directory.media"  select="'media'" />
 <xsl:param name="directory.knowls" select="'knowls'" />
+<!-- Table captions can be placed above or below the table -->
+<!-- according to the value of table.caption.position      -->
+<xsl:param name="table.caption.position" select="'below'" />
 <!-- Strip whitespace text nodes from container elements                    -->
 <!-- Improve source readability with whitespace control in text output mode -->
 <!-- Newlines with &#xa; : http://stackoverflow.com/questions/723226/producing-a-new-line-in-xslt -->

--- a/xsl/mathbook-common.xsl
+++ b/xsl/mathbook-common.xsl
@@ -116,7 +116,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:strip-space elements="ul ol dl" />
 <xsl:strip-space elements="md mdn" />
 <xsl:strip-space elements="sage figure index" />
-<xsl:strip-space elements="table tgroup thead tbody row" />
+<xsl:strip-space elements="table tgroup thead tbody row coltypes col" />
 
 <!-- ######### -->
 <!-- Variables -->

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -1338,10 +1338,15 @@ is just flat out on the page, as if printed there.
 <!-- Should be able to replace this by extant XSLT for this conversion -->
 <xsl:template match="table">
     <figure>
-        <xsl:apply-templates select="caption" />
+        <xsl:if test="$table.caption.position='above'">
+            <xsl:apply-templates select="caption" />
+        </xsl:if>
         <table class="center">
             <xsl:apply-templates select="*[not(self::caption)]" />
         </table>
+        <xsl:if test="$table.caption.position='below'">
+            <xsl:apply-templates select="caption" />
+        </xsl:if>
     </figure>
 </xsl:template>
 

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -1338,10 +1338,10 @@ is just flat out on the page, as if printed there.
 <!-- Should be able to replace this by extant XSLT for this conversion -->
 <xsl:template match="table">
     <figure>
+        <xsl:apply-templates select="caption" />
         <table class="center">
             <xsl:apply-templates select="*[not(self::caption)]" />
         </table>
-        <xsl:apply-templates select="caption" />
     </figure>
 </xsl:template>
 
@@ -1354,15 +1354,110 @@ is just flat out on the page, as if printed there.
 </xsl:template>
 <xsl:template match="thead/row">
     <tr><xsl:apply-templates /></tr>
-    <tr><xsl:apply-templates mode="hline" /></tr>
 </xsl:template>
 <xsl:template match="tbody/row">
     <tr><xsl:apply-templates /></tr>
 </xsl:template>
 <!-- With a parent axis, get overrides easily? -->
-<xsl:template match="thead/row/entry"><td align="{../../../@align}"><xsl:apply-templates /></td></xsl:template>
+<xsl:template match="thead/row/entry[descendant::tgroup]"><td align="{../../../@align}"><xsl:apply-templates /></td></xsl:template>
 <xsl:template match="thead/row/entry" mode="hline"><td class="hline"><hr /></td></xsl:template>
-<xsl:template match="tbody/row/entry"><td align="{../../../@align}"><xsl:apply-templates /></td></xsl:template>
+<xsl:template match="tbody/row/entry[descendant::tgroup]"><td align="{../../../@align}"><xsl:apply-templates /></td></xsl:template>
+
+<!-- td match in thead when tgroup tag is *not* used -->
+<xsl:template match="thead/row/entry[not(descendant::tgroup)]">
+  <!-- get the column *position* of the current entry, e.g 1st, 2nd, 3rd -->
+  <xsl:variable name="columnPos">
+    <xsl:value-of select="position()" />
+  </xsl:variable>
+  <!-- get the column *type* of the current entry, e.g left, center, right, decimal -->
+  <xsl:variable name="columnType">
+    <xsl:value-of select="(../../../coltypes/col[@align])[position()=$columnPos]/@align" />
+  </xsl:variable>
+  <!-- set up <td>...</td> -->
+  <xsl:element name="td">
+    <xsl:choose>
+      <!-- when columnType is decimal we have to use
+           <td style="center">CONTENTS</td>
+                -->
+        <xsl:when test="$columnType='decimal'">
+            <xsl:attribute name="style">text-align:center</xsl:attribute>
+            <xsl:apply-templates />
+        </xsl:when>
+        <!-- when columnType is *not* decimal <td text-align="$columnType"> -->
+        <xsl:otherwise>
+            <xsl:attribute name="style">text-align:<xsl:value-of select="$columnType"/></xsl:attribute>
+            <!-- insert contents of <entry> -->
+            <xsl:apply-templates />
+        </xsl:otherwise>
+    </xsl:choose>
+  </xsl:element>
+</xsl:template>
+
+<!-- td match in tbody when tgroup tag is *not* used -->
+<xsl:template match="tbody/row/entry[not(descendant::tgroup)]">
+  <!-- get the column *position* of the current entry, e.g 1st, 2nd, 3rd -->
+  <xsl:variable name="columnPos">
+    <xsl:value-of select="position()" />
+  </xsl:variable>
+  <!-- get the column *type* of the current entry, e.g left, center, right, decimal -->
+  <xsl:variable name="columnType">
+    <xsl:value-of select="(../../../coltypes/col[@align])[position()=$columnPos]/@align" />
+  </xsl:variable>
+  <!-- set up <td>...</td> -->
+  <xsl:element name="td">
+    <xsl:choose>
+      <!-- when columnType is decimal we have to use
+           <td style="width:TOTALwidthEM">
+                <span class="left" style="width:LENGTHofCELL+em">xxx</span>
+           </td>
+                -->
+        <xsl:when test="$columnType='decimal'">
+          <!-- store the cell value into the variable $cell -->
+          <xsl:variable name="cell">
+            <xsl:value-of select="."/>
+          </xsl:variable>
+          <!-- grab the format, e.g 2.4 or 3.5, etc-->
+          <xsl:variable name="format">
+            <xsl:value-of select="(../../../coltypes/col[@align])[position()=$columnPos]/@format"/>
+          </xsl:variable>
+          <!-- the format attribute will be format="2.4", for example,
+               so we need to grab the 2 and the 4 -->
+          <xsl:variable name="integerPart">
+            <xsl:value-of select="substring-before($format,'.')"/>
+          </xsl:variable>
+          <xsl:variable name="fractionalPart">
+            <xsl:value-of select="substring-after($format,'.')"/>
+          </xsl:variable>
+          <!-- we need the length of the string *after* the decimal place 
+               a bit of adjustment when the cell has *no* decimal -->
+          <xsl:variable name="fractionalPartLength">
+            <xsl:choose>
+              <xsl:when test="contains($cell,'.')">
+                  <xsl:value-of select="string-length(substring-after($cell,'.'))"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:text>-.5</xsl:text>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:variable>
+          <!-- form <td style="width:TOTALwidthEM"> -->
+          <xsl:attribute name="style">width:<xsl:value-of select="$integerPart+$fractionalPart+.5" />ex</xsl:attribute>
+          <!-- form <span class="left" style="width:LENGTHofCELLem">XXX</span> -->
+          <xsl:element name="span">
+            <xsl:attribute name="class">left</xsl:attribute>
+            <xsl:attribute name="style">width:<xsl:value-of select="$integerPart+.5+$fractionalPartLength"/>ex</xsl:attribute>
+            <xsl:text>\(</xsl:text><xsl:value-of select="$cell"/><xsl:text>\)</xsl:text>
+          </xsl:element>
+        </xsl:when>
+        <!-- when columnType is *not* decimal <td text-align="$columnType"> -->
+        <xsl:otherwise>
+            <xsl:attribute name="style">text-align:<xsl:value-of select="$columnType"/></xsl:attribute>
+            <!-- insert contents of <entry> -->
+            <xsl:apply-templates />
+        </xsl:otherwise>
+    </xsl:choose>
+  </xsl:element>
+</xsl:template>
 
 <!-- Caption of a figure or table                  -->
 <!-- All the relevant information is in the parent -->
@@ -2683,6 +2778,13 @@ $(function () {
 <xsl:template name="css">
     <link href="{$html.css.server}/mathbook/stylesheets/{$html.css.file}" rel="stylesheet" type="text/css" />
     <link href="http://aimath.org/mathbook/mathbook-add-on.css" rel="stylesheet" type="text/css" />
+    <style>/*for decimal alignment */
+      span.left { float: left; text-align: right; }
+/* table styles */
+table thead { border-top: 2px solid #000; }
+table tbody { border-top: 1px solid #000; 
+border-bottom: 2px solid #000; 
+</style>
 </xsl:template>
 
 

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -510,9 +510,11 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>{\end{mbxfigure}}&#xa;</xsl:text>
         </xsl:if>
         <xsl:if test="//table">
-            <!-- captions of tables should be on top: 
+            <!-- captions of tables can go above or below the table: 
                 http://tex.stackexchange.com/questions/3243/why-should-a-table-caption-be-placed-above-the-table -->
-            <xsl:text>\floatstyle{plaintop}&#xa;</xsl:text>
+            <xsl:if test="$table.caption.position='above'">
+                <xsl:text>\floatstyle{plaintop}&#xa;</xsl:text>
+            </xsl:if>
             <xsl:text>\newfloat{mbxtable}{H}{lot}</xsl:text>
             <!-- See numbering-theorems variable being set in mathbook-common.xsl -->
             <xsl:text>[</xsl:text>


### PR DESCRIPTION
Alex,
Not sure how you want to handle this--I plan to submit this pull request to Rob at the same time. Perhaps we might wait to see if he has a chance to review it? Not sure.... I'll put the details below, for reference.

---

This pull request adds a lot of enhancements to the table capabilities of MBX, including:
- added `booktabs` package, see: http://www.ctan.org/tex-archive/macros/latex/contrib/booktabs/
- added `toprule`, `midrule`, `bottomrule` to `latex` version (from `booktabs`)
- added `caption` package for customising `latex` captions
- added table `css` to `html` version (not sure where else to put this? `mathbook.css` isn't loaded?)
- moved `table caption` to the top of a table, see for example: http://tex.stackexchange.com/questions/3243/why-should-a-table-caption-be-placed-above-the-table
- added `decimal alignment` capability to both `latex` and `html`, including heading command
- original tables with `tgroup` still work as before

To test, run `xsltproc` using both `xsl/mathbook-latex.xsl` and `xsl/mathbook-html/xsl` on `examples/sample-article.xml`, and have a look in section 6; you should see:
## LaTeX version

![screenshot from 2015-01-30 21 12 29](https://cloud.githubusercontent.com/assets/2224480/5983393/c11167cc-a8c4-11e4-8f62-efdc4379569a.png)
## html version

![screenshot from 2015-01-30 21 13 51](https://cloud.githubusercontent.com/assets/2224480/5983412/f58a3db2-a8c4-11e4-8953-11bc75a029fe.png)

You should see new sample tables in `examples/sample-article.xml`; note that the original approach using `tgroup` still works. 
