### PR TITLE
changed quant to quantity

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -1478,8 +1478,8 @@ is just flat out on the page, as if printed there.
 
 
 <!-- Numbers, units, quantities                     -->
-<!-- quant                                          -->
-<xsl:template match="quant">
+<!-- quantity                                       -->
+<xsl:template match="quantity">
     <!-- warning if there is no content -->
     <xsl:if test="not(descendant::unit) and not(descendant::per) and not(descendant::mag)">
         <xsl:message terminate="no">
@@ -1517,7 +1517,7 @@ is just flat out on the page, as if printed there.
     <xsl:apply-templates />
 </xsl:template>
 
-<!-- unit and per children of a quant element       -->
+<!-- unit and per children of a quantity element    -->
 <!-- have a mandatory base attribute                -->
 <!-- may have prefix and exp attributes             -->
 <!-- base and prefix are not abbreviations          --> 

--- a/xsl/mathbook-latex.xsl
+++ b/xsl/mathbook-latex.xsl
@@ -343,7 +343,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>%% Used to markup acronyms, defaults is no effect&#xa;</xsl:text>
         <xsl:text>\newcommand{\acronym}[1]{#1}&#xa;</xsl:text>
     </xsl:if>
-    <xsl:if test="//quant">
+    <xsl:if test="//quantity">
         <xsl:text>%% Used for units and number formatting&#xa;</xsl:text>
         <xsl:text>\usepackage[per-mode=fraction]{siunitx}&#xa;</xsl:text>
         <xsl:text>%% Common non-SI units&#xa;</xsl:text>
@@ -1433,8 +1433,8 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
 
 <!-- Numbers, units, quantities                     -->
-<!-- quant                                          -->
-<xsl:template match="quant">
+<!-- quantity                                       -->
+<xsl:template match="quantity">
     <!-- warning if there is no content -->
     <xsl:if test="not(descendant::unit) and not(descendant::per) and not(descendant::mag)">
         <xsl:message terminate="no">


### PR DESCRIPTION
This was one of Rob's suggestions at https://groups.google.com/forum/#!topic/mathbook-xml-support/La6yGblwIt0.

He has several more substantial suggestions. Some of which I think became moot as I worked on this feature earlier. But some of which I'm still scratching me head about. 

I pushed this one commit up, so now Rob's seeing `quantity` instead of `quant`. So I thought I should keep our dev up to date with that.
